### PR TITLE
Fix PHP8 deprecated error message (#2)

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -716,7 +716,7 @@ final class Str implements \Countable {
 		return $this->rawString;
 	}
 
-	private function trimInternal(callable $func, $charactersToRemove = null, $alwaysRemoveWhitespace) {
+	private function trimInternal(callable $func, $charactersToRemove, $alwaysRemoveWhitespace) {
 		if ($alwaysRemoveWhitespace === null) {
 			$alwaysRemoveWhitespace = false;
 		}


### PR DESCRIPTION
```text
Deprecated: Required parameter $alwaysRemoveWhitespace follows optional parameter $charactersToRemove in /app/src/Str.php on line 719
```

All tests passed.